### PR TITLE
Avoid copying WAL segments before divergence to speed up pg_rewind

### DIFF
--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -25,7 +25,6 @@
 #include "fe_utils/recovery_gen.h"
 #include "fe_utils/string_utils.h"
 #include "file_ops.h"
-#include "filemap.h"
 #include "getopt_long.h"
 #include "pg_rewind.h"
 #include "rewind_source.h"
@@ -68,6 +67,8 @@ bool		showprogress = false;
 bool		dry_run = false;
 bool		do_sync = true;
 bool		restore_wal = false;
+
+static XLogRecPtr   divergerec;
 
 /* Target history */
 TimeLineHistoryEntry *targetHistory;
@@ -129,7 +130,6 @@ main(int argc, char **argv)
 	};
 	int			option_index;
 	int			c;
-	XLogRecPtr	divergerec;
 	int			lastcommontliIndex;
 	XLogRecPtr	chkptrec;
 	TimeLineID	chkpttli;
@@ -488,6 +488,40 @@ main(int argc, char **argv)
 	pg_log_info("Done!");
 
 	return 0;
+}
+
+file_action_t
+decide_wal_file_action(const char *fname)
+{
+    TimeLineID  file_tli;
+    XLogSegNo	file_segno;
+    XLogSegNo   last_common_segno;
+
+    /*
+	 * Find last common WAL segment number between source and target before
+	 * divergence given last common LSN (byte position).
+	 */
+    XLByteToSeg(divergerec, last_common_segno, ControlFile_target.xlog_seg_size);
+
+    /* Get current WAL segment number given current segment file name. */
+    XLogFromFileName(fname, &file_tli, &file_segno, ControlFile_target.xlog_seg_size);
+
+    /*
+     * Avoid unnecessarily copying WAL segment files created before last common
+     * segment to avoid performance penalty when many WAL segment files are
+     * retained on source and copied to target.
+     *
+     * These files are already common between new source (old target) and new
+     * target (old source). Only WAL segment files after the last common segment
+     * number on the new source need to be copied to the new target.
+     */
+    if (file_segno < last_common_segno) {
+        pg_log_debug("WAL file entry \"%s\" not copied to target", fname);
+        return FILE_ACTION_NONE;
+    }
+
+    pg_log_debug("WAL file entry \"%s\" copied to target", fname);
+    return FILE_ACTION_COPY;
 }
 
 /*

--- a/src/bin/pg_rewind/pg_rewind.h
+++ b/src/bin/pg_rewind/pg_rewind.h
@@ -14,6 +14,7 @@
 #include "access/timeline.h"
 #include "common/logging.h"
 #include "datapagemap.h"
+#include "filemap.h"
 #include "libpq-fe.h"
 #include "storage/block.h"
 #include "storage/relfilenode.h"
@@ -44,6 +45,7 @@ extern void findLastCheckpoint(const char *datadir, XLogRecPtr searchptr,
 							   const char *restoreCommand);
 extern XLogRecPtr readOneRecord(const char *datadir, XLogRecPtr ptr,
 								int tliIndex, const char *restoreCommand);
+extern file_action_t decide_wal_file_action(const char *fname);
 
 /* in pg_rewind.c */
 extern void progress_report(bool finished);


### PR DESCRIPTION
**Description**

- Optimizes `pg_rewind` by skipping (not copying) any WAL segment files that are created before the last common LSN checkpoint before the new source server forked off into a new timeline
- To be safe, we still copy over the last common WAL segment file in full (found given last common LSN)

**Motivation**

In production, 95%+ of our WAL segment files are the same between the source and target server. Currently by default, `pg_rewind` will blindly copy over all WAL segment files from source to target server. As a result, during failovers, the newly promoted primary (old standby server) will unnecessarily copy over many terabytes of WAL files to the new standby (old primary server) even if they are common and originate before the last common WAL divergence point (LSN).

**Postgres WAL Anatomy**

`XLogSegNo`
- Represents a WAL segment
- Is internal to the Postgres codebase, the current WAL segment denoted by an integer 
- Globally references a WAL segment from any WAL sequence, bounded within [0, inf) rather than [0, 255)

`XLogRecPtr`
- Represents byte stream position in WALs (internal LSN representation)
- Most precise measurement of WAL location, can derive the current sequence and segment using it (the reverse is not possible)
- Externally represented 8 bit hexadecimal encoding (ex. 16/B374D848)

**Note** while the LSN is internally referenced by `XLogRecPtr`, the LSN is also externally represented as an 8 bit encoded hexadecimal.

cc @viggy28